### PR TITLE
bug fix: reset notes-element before render notes

### DIFF
--- a/src/view.js
+++ b/src/view.js
@@ -39,6 +39,7 @@ const renderNotes = () => {
     if (!notes) return
     
     const notesEl = document.querySelector('#notes')
+    notesEl.innerHTML = ''
     
     getFilteredNotes(notes).forEach((note) => {
         notesEl.append(generateNoteDOM(note))


### PR DESCRIPTION
view.js のrenderNotes()を修正
#4 を解決